### PR TITLE
Fix unit tests

### DIFF
--- a/ManagedFusion.Rewriter.sln
+++ b/ManagedFusion.Rewriter.sln
@@ -5,7 +5,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		example - ManagedFusion.Rewriter.txt = example - ManagedFusion.Rewriter.txt
 		ManagedFusion.Rewriter.msbuild = ManagedFusion.Rewriter.msbuild
-		README.txt = README.txt
 		rewrite_schema.xml = rewrite_schema.xml
 	EndProjectSection
 EndProject

--- a/test/ManagedFusion.Rewriter.Tests/ApacheStyleTest.cs
+++ b/test/ManagedFusion.Rewriter.Tests/ApacheStyleTest.cs
@@ -62,7 +62,7 @@ RewriteRule ^/([a-z]+)\.aspx  /$1 []");
 			var url = new Uri("http://www.somesite.com/test.aspx");
 			var context = HttpHelpers.MockHttpContext(url);
 			var target = CreateRuleSet(@"
-RewriteModule PostQueryString  ManagedFusion.Rewriter.Test.TestRuleAction,  ManagedFusion.Rewriter.Tests
+RewriteModule PostQueryString  ManagedFusion.Rewriter.Tests.TestRuleAction,  ManagedFusion.Rewriter.Tests
 RewriteRule(,PostQueryString) ^(.*)$  $1");
 
 			Uri expected = new Uri("http://www.somesite.com/pass");

--- a/test/ManagedFusion.Rewriter.Tests/App.config
+++ b/test/ManagedFusion.Rewriter.Tests/App.config
@@ -6,7 +6,7 @@
 	<managedFusion.rewriter xmlns="http://managedfusion.com/xsd/managedFusion/rewriter">
 		<rules engine="Apache"/>
 		<rewriter>
-			<proxy useAsyncProxy="true" proxyType="ManagedFusion.Rewriter.Test.TestProxyHandler, ManagedFusion.Rewriter.Tests" proxyAsyncType="ManagedFusion.Rewriter.Test.TestProxyAsyncHandler, ManagedFusion.Rewriter.Tests"/>
+			<proxy useAsyncProxy="true" proxyType="ManagedFusion.Rewriter.Tests.TestProxyHandler, ManagedFusion.Rewriter.Tests" proxyAsyncType="ManagedFusion.Rewriter.Tests.TestProxyAsyncHandler, ManagedFusion.Rewriter.Tests"/>
 		</rewriter>
 	</managedFusion.rewriter>
 	<startup>


### PR DESCRIPTION
The following unit tests fail:
- RewriteModule_IRuleAction
- ProxyType
- ProxyAsyncType

The issue was related with the name of the namespaces being slightly different than the one being used to run the tests.

Also, removed the file README.txt which does not exist in the solution.
