### PR TITLE
Fixed proxy issues without trailing slash

### DIFF
--- a/ManagedFusion.Rewriter.sln
+++ b/ManagedFusion.Rewriter.sln
@@ -5,7 +5,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		example - ManagedFusion.Rewriter.txt = example - ManagedFusion.Rewriter.txt
 		ManagedFusion.Rewriter.msbuild = ManagedFusion.Rewriter.msbuild
-		README.txt = README.txt
 		rewrite_schema.xml = rewrite_schema.xml
 	EndProjectSection
 EndProject

--- a/src/ManagedFusion.Rewriter.csproj
+++ b/src/ManagedFusion.Rewriter.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>ManagedFusion.Rewriter</AssemblyName>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ManagedFusion.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\Serverocity\serverocity.com\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/src/RewriterModule.cs
+++ b/src/RewriterModule.cs
@@ -160,8 +160,11 @@ namespace ManagedFusion.Rewriter
 			var context = new HttpContextWrapper(((HttpApplication)sender).Context);
 
 			// check to see if this is a proxy request
-			if (context.Items.Contains(Manager.ProxyHandlerStorageName))
-				context.RewritePath("~/RewriterProxy.axd");
+            if (context.Items.Contains(Manager.ProxyHandlerStorageName))
+            {
+                var proxyHandler = context.Items[Manager.ProxyHandlerStorageName] as IHttpHandler;
+                context.RemapHandler(proxyHandler);
+            }
 		}
 
 		/// <summary>

--- a/test/ManagedFusion.Rewriter.Tests/App.config
+++ b/test/ManagedFusion.Rewriter.Tests/App.config
@@ -10,6 +10,6 @@
 		</rewriter>
 	</managedFusion.rewriter>
 	<startup>
-		<supportedRuntime version="v2.0.50727"/>
-	</startup>
+		
+	<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup>
 </configuration>

--- a/test/ManagedFusion.Rewriter.Tests/ManagedFusion.Rewriter.Tests.csproj
+++ b/test/ManagedFusion.Rewriter.Tests/ManagedFusion.Rewriter.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ManagedFusion.Rewriter.Tests</RootNamespace>
     <AssemblyName>ManagedFusion.Rewriter.Tests</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>
@@ -54,6 +54,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -63,6 +64,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
@@ -121,7 +123,9 @@
     <None Include="..\..\src\ManagedFusion.snk">
       <Link>ManagedFusion.snk</Link>
     </None>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ManagedFusion.Rewriter.Tests/packages.config
+++ b/test/ManagedFusion.Rewriter.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.0.10827" targetFramework="net35" />
+  <package id="Moq" version="4.0.10827" targetFramework="net35" requireReinstallation="True" />
   <package id="NUnit" version="2.6.2" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
(From http://stackoverflow.com/q/19301437/147507)
## Description of problem

I'm using ManagedFusion Rewriter as a reverse proxy. The configuration is fairly simple:

```
RewriteRule ^/api/(.*) http://www.example.com/api/$1 [P]
```

This will work pretty much for any URL. However, if the URL happens to _not_ end on a trailing slash, it will fail.

A request like this will go fine perfectly: `GET api/report/`

```
2013-10-10T11:27:11 [Rewrite] Input: http://localhost:50070/api/report/
2013-10-10T11:27:11 [Rule 0] Input: /api/report/
2013-10-10T11:27:11 [Rule 0] Rule Pattern Matched
2013-10-10T11:27:11 [Rule 0] Output: http://www.example.com/api/report/
2013-10-10T11:27:11 [Rewrite] Proxy: http://www.example.com/api/report/
2013-10-10T11:27:11 **********************************************************************************
2013-10-10T11:27:11 [Proxy] Request: http://www.example.com/api/report/
2013-10-10T11:27:12 [Proxy] System.Net.HttpWebResponse
2013-10-10T11:27:12 [Proxy] Received '200 OK'
2013-10-10T11:27:12 [Proxy] Response: http://localhost:50070/api/report/
2013-10-10T11:27:12 [Proxy] Response is being buffered
2013-10-10T11:27:12 [Proxy] Responding '200 OK'
```

However, a request like this will return a 404 without even making the request on the proxied URL: `GET api/report/1`

```
2013-10-10T11:27:13 [Rewrite] Input: http://localhost:50070/api/report/1
2013-10-10T11:27:13 [Rule 0] Input: /api/report/1
2013-10-10T11:27:13 [Rule 0] Rule Pattern Matched
2013-10-10T11:27:13 [Rule 0] Output: http://www.example.com/api/report/1
2013-10-10T11:27:13 [Rewrite] Proxy: http://www.example.com/api/report/1
(the log file finishes right here)
```

This is my whole configuration file:

```
RewriteEngine On
RewriteLog "log.txt"
RewriteLogLevel 9
RewriteRule ^/api/(.*) http://www.example.com/api/$1 [P]
```
## Description of solution

The class ManagedFusion.Rewriter.RewriterModule contains the following two methods:

```
private void context_PostResolveRequestCache(object sender, EventArgs e)
{
    var context = new HttpContextWrapper(((HttpApplication)sender).Context);

    // check to see if this is a proxy request
    if (context.Items.Contains(Manager.ProxyHandlerStorageName))
        context.RewritePath("~/RewriterProxy.axd");
}

private void context_PostMapRequestHandler(object sender, EventArgs e)
{
    var context = new HttpContextWrapper(((HttpApplication)sender).Context);

    // check to see if this is a proxy request
    if (context.Items.Contains(Manager.ProxyHandlerStorageName))
    {
        var proxy = context.Items[Manager.ProxyHandlerStorageName] as IHttpProxyHandler;

        context.RewritePath("~" + proxy.ResponseUrl.PathAndQuery);
        context.Handler = proxy;
    }
}
```

As the names imply, the first one is the handler of `PostResolveRequestCache`, while the second one is the handler for `PostMapRequestHandler`.

In both of my example requests, the `PostResolveRequestCache` handler was being invoked and working fine. However, for my failing request, `PostMapRequestHandler` was not being executed.

This made me think that maybe, for some reason, rewriting a specific resource that does not look like a directory to a resource that looks like a file through the usage of `RewritePath` was preventing the actual actual handler from being picked up, thus preventing the raising of `PostMapRequestHandler`.

As such, I upgraded the Rewriter project from .NET 3.5 to 4.5 and replaced these lines:

```
if (context.Items.Contains(Manager.ProxyHandlerStorageName))
    context.RewritePath("~/RewriterProxy.axd");
```

by these ones

```
if (context.Items.Contains(Manager.ProxyHandlerStorageName)) {
    var proxyHandler = context.Items[Manager.ProxyHandlerStorageName] as IHttpHandler;
    context.RemapHandler(proxyHandler);
}
```

With this, all the requests were being properly picked up by the handler and started working.

---

As a side note, I had some mistakes in the original rules, instead of

```
RewriteRule ^/api/(.*) http://www.example.com/api/$1 [P]
```

It should have been:

```
RewriteRule ^/api/(.*) http://www.example.com/api/$1 [QSA,P,NC]
```
- `QSA` to append the query string of the original request
- `NC` to match the regex case insensitive
